### PR TITLE
fixed a typo

### DIFF
--- a/_includes/partials/install_sql_server_linux_ubuntu.md
+++ b/_includes/partials/install_sql_server_linux_ubuntu.md
@@ -1,7 +1,7 @@
 Note: To ensure optimal performance of SQL Server, your machine should have at least 4 GB of memory.
 If you need to get Ubuntu, check out the Ubuntu Downloads website.
 
-1. Register the Microsoft Linux repositories and add they keys
+1. Register the Microsoft Linux repositories and add their keys
 
     ```terminal
     curl https://packages.microsoft.com/keys/microsoft.asc | sudo apt-key add -


### PR DESCRIPTION
The sentence:

> If you need to get Ubuntu, check out the Ubuntu Downloads website.

looks odd to me. I think if someone reached here then he should know about Ubuntu or at least know how to obtain it! (maybe adding a link to the download page won't make it too odd!)