### PR TITLE
Cleaning up go sample code

### DIFF
--- a/_includes/partials/go/crudunix.md
+++ b/_includes/partials/go/crudunix.md
@@ -173,7 +173,8 @@ import (
     "database/sql"
     "context"
     "log"
-    "fmt" 
+    "fmt"
+    "errors"
 )
 
 var db *sql.DB
@@ -194,65 +195,89 @@ func main() {
     // Create connection pool
     db, err = sql.Open("sqlserver", connString)
     if err != nil {
-        log.Fatal("Error creating connection pool:", err.Error())
+        log.Fatal("Error creating connection pool: ", err.Error())
+    }
+    ctx := context.Background()
+    err = db.PingContext(ctx)
+    if err != nil {
+        log.Fatal(err.Error())
     }
     fmt.Printf("Connected!\n")
 
     // Create employee
-    createId, err := CreateEmployee("Jake", "United States")
-    fmt.Printf("Inserted ID: %d successfully.\n", createId)
+    createID, err := CreateEmployee("Jake", "United States")
+    if err != nil {
+        log.Fatal("Error creating Employee: ", err.Error())
+    }
+    fmt.Printf("Inserted ID: %d successfully.\n", createID)
 
     // Read employees
     count, err := ReadEmployees()
-    fmt.Printf("Read %d rows successfully.\n", count)
+    if err != nil {
+        log.Fatal("Error reading Employees: ", err.Error())
+    }
+    fmt.Printf("Read %d row(s) successfully.\n", count)
 
     // Update from database
-    updateId, err := UpdateEmployee("Jake", "Poland")
-    fmt.Printf("Updated row with ID: %d successfully.\n", updateId)
+    updatedRows, err := UpdateEmployee("Jake", "Poland")
+    if err != nil {
+        log.Fatal("Error updating Employee: ", err.Error())
+    }
+    fmt.Printf("Updated %d row(s) successfully.\n", updatedRows)
 
     // Delete from database
-    rows, err := DeleteEmployee("Jake")
-    fmt.Printf("Deleted %d rows successfully.\n", rows)
+    deletedRows, err := DeleteEmployee("Jake")
+    if err != nil {
+        log.Fatal("Error deleting Employee: ", err.Error())
+    }
+    fmt.Printf("Deleted %d row(s) successfully.\n", deletedRows)
 }
 
+// CreateEmployee inserts an employee record
 func CreateEmployee(name string, location string) (int64, error) {
     ctx := context.Background()
     var err error
 
     if db == nil {
-        log.Fatal("What?")
+        err = errors.New("CreateEmployee: db is null")
+        return -1, err
     }
 
     // Check if database is alive.
     err = db.PingContext(ctx)
     if err != nil {
-        log.Fatal("Error pinging database: " + err.Error())
+        return -1, err
     }
 
-    tsql := fmt.Sprintf("INSERT INTO TestSchema.Employees (Name, Location) VALUES (@Name,@Location);")
+    tsql := "INSERT INTO TestSchema.Employees (Name, Location) VALUES (@Name, @Location); select convert(bigint, SCOPE_IDENTITY());"
 
-    // Execute non-query with named parameters
-    result, err := db.ExecContext(
-        ctx, 
-        tsql, 
-        sql.Named("Location", location), 
-        sql.Named("Name", name))
+    stmt, err := db.Prepare(tsql)
+    if err != nil {
+        return -1, err
+    }
+    defer stmt.Close()
 
-	if err != nil {
-		log.Fatal("Error inserting new row: " + err.Error())
-		return -1, err
-	}
+    row := stmt.QueryRowContext(
+        ctx,
+        sql.Named("Name", name),
+        sql.Named("Location", location))
+    var newID int64
+    err = row.Scan(&newID)
+    if err != nil {
+        return -1, err
+    }
 
-	return result.LastInsertId()
+    return newID, nil
 }
 
+// ReadEmployees reads all employee records
 func ReadEmployees() (int, error) {
     ctx := context.Background()
-    
+
     // Check if database is alive.
     err := db.PingContext(ctx)
     if err != nil {
-        log.Fatal("Error pinging database: " + err.Error())
+        return -1, err
     }
 
     tsql := fmt.Sprintf("SELECT Id, Name, Location FROM TestSchema.Employees;")
@@ -260,13 +285,12 @@ func ReadEmployees() (int, error) {
     // Execute query
     rows, err := db.QueryContext(ctx, tsql)
     if err != nil {
-        log.Fatal("Error reading rows: " + err.Error())
         return -1, err
     }
 
     defer rows.Close()
 
-    var count int = 0
+    var count int
 
     // Iterate through the result set.
     for rows.Next() {
@@ -276,7 +300,6 @@ func ReadEmployees() (int, error) {
         // Get values from row.
         err := rows.Scan(&id, &name, &location)
         if err != nil {
-            log.Fatal("Error reading rows: " + err.Error())
             return -1, err
         }
 
@@ -287,48 +310,46 @@ func ReadEmployees() (int, error) {
     return count, nil
 }
 
-// Update an employee's information
+// UpdateEmployee updates an employee's information
 func UpdateEmployee(name string, location string) (int64, error) {
     ctx := context.Background()
-    
+
     // Check if database is alive.
     err := db.PingContext(ctx)
     if err != nil {
-        log.Fatal("Error pinging database: " + err.Error())
-    }
-
-    tsql := fmt.Sprintf("UPDATE TestSchema.Employees SET Location = @Location WHERE Name= @Name")
-
-    // Execute non-query with named parameters
-    result, err := db.ExecContext(
-        ctx, 
-        tsql, 
-        sql.Named("Location", location), 
-        sql.Named("Name", name))
-    if err != nil {
-        log.Fatal("Error updating row: " + err.Error())
         return -1, err
     }
 
-    return result.LastInsertId()
+    tsql := fmt.Sprintf("UPDATE TestSchema.Employees SET Location = @Location WHERE Name = @Name")
+
+    // Execute non-query with named parameters
+    result, err := db.ExecContext(
+        ctx,
+        tsql,
+        sql.Named("Location", location),
+        sql.Named("Name", name))
+    if err != nil {
+        return -1, err
+    }
+
+    return result.RowsAffected()
 }
 
-// Delete an employee from database
+// DeleteEmployee deletes an employee from the database
 func DeleteEmployee(name string) (int64, error) {
     ctx := context.Background()
-    
+
     // Check if database is alive.
     err := db.PingContext(ctx)
     if err != nil {
-        log.Fatal("Error pinging database: " + err.Error())
+        return -1, err
     }
 
-    tsql := fmt.Sprintf("DELETE FROM TestSchema.Employees WHERE Name=@Name;")
+    tsql := fmt.Sprintf("DELETE FROM TestSchema.Employees WHERE Name = @Name;")
 
     // Execute non-query with named parameters
     result, err := db.ExecContext(ctx, tsql, sql.Named("Name", name))
     if err != nil {
-        fmt.Println("Error deleting row: " + err.Error())
         return -1, err
     }
 
@@ -349,9 +370,9 @@ ID: 1, Name: Jared, Location: Australia
 ID: 2, Name: Nikita, Location: India
 ID: 3, Name: Tom, Location: Germany
 ID: 4, Name: Jake, Location: United States
-Read 4 rows successfully.
-Updated row with ID: 4 successfully.
-Deleted 1 rows successfully.
+Read 4 row(s) successfully.
+Updated 1 row(s) successfully.
+Deleted 1 row(s) successfully.
 ```
 
 ## Step 2.2 Create a Go app that connects to SQL Server using the popular GORM


### PR DESCRIPTION
Cleaning up error logic flow, correcting some compiler warnings, and replacing the no-longer-supported LastInsertId() function with an appropriate alternative.