### PR TITLE
Sqldev update

### DIFF
--- a/_includes/partials/install_sqlcmd_linux_rhel.md
+++ b/_includes/partials/install_sqlcmd_linux_rhel.md
@@ -1,12 +1,16 @@
 [SQLCMD](https://docs.microsoft.com/en-us/sql/linux/sql-server-linux-connect-and-query-sqlcmd){:target="_blank"} is a command line tool that enables you to connect to SQL Server and run queries.
 
 ```terminal
-curl https://packages.microsoft.com/config/rhel/7/prod.repo | sudo tee /etc/yum.repos.d/mssql-tools.repo
+sudo su
+curl https://packages.microsoft.com/config/rhel/7/prod.repo > /etc/yum.repos.d/mssql-tools.repo
 sudo ACCEPT_EULA=Y yum install msodbcsql17 mssql-tools
-sudo yum install unixODBC-devel
+exit
+sudo yum remove unixODBC-utf16 unixODBC-utf16-devel #to avoid conflicts
+sudo ACCEPT_EULA=Y yum install msodbcsql17 mssql-tools
 echo 'export PATH="$PATH:/opt/mssql-tools/bin"' >> ~/.bash_profile
 echo 'export PATH="$PATH:/opt/mssql-tools/bin"' >> ~/.bashrc
 source ~/.bashrc
+sudo yum install unixODBC-devel
 ```
 
 After installing SQLCMD, you can connect to SQL Server using the following command:

--- a/_includes/partials/install_sqlcmd_linux_sles.md
+++ b/_includes/partials/install_sqlcmd_linux_sles.md
@@ -3,12 +3,11 @@
 ```terminal
 sudo zypper ar https://packages.microsoft.com/config/sles/12/prod.repo
 sudo zypper update
-exit
 sudo ACCEPT_EULA=Y zypper install msodbcsql17 mssql-tools
-sudo zypper install unixODBC-devel
 echo 'export PATH="$PATH:/opt/mssql-tools/bin"' >> ~/.bash_profile
 echo 'export PATH="$PATH:/opt/mssql-tools/bin"' >> ~/.bashrc
 source ~/.bashrc
+sudo zypper install unixODBC-devel
 ```
 
 

--- a/_includes/partials/install_sqlcmd_linux_ubuntu.md
+++ b/_includes/partials/install_sqlcmd_linux_ubuntu.md
@@ -12,7 +12,8 @@ sudo ACCEPT_EULA=Y apt-get install msodbcsql17 mssql-tools
 echo 'export PATH="$PATH:/opt/mssql-tools/bin"' >> ~/.bash_profile
 echo 'export PATH="$PATH:/opt/mssql-tools/bin"' >> ~/.bashrc
 source ~/.bashrc
-sudo apt-get install unixodbc-dev```
+sudo apt-get install unixodbc-dev
+```
 
 After installing SQLCMD, you can connect to SQL Server using the following command:
 

--- a/_includes/partials/install_sqlcmd_linux_ubuntu.md
+++ b/_includes/partials/install_sqlcmd_linux_ubuntu.md
@@ -1,6 +1,7 @@
 [SQLCMD](https://docs.microsoft.com/en-us/sql/linux/sql-server-linux-connect-and-query-sqlcmd){:target="_blank"} is a command line tool that enables you to connect to SQL Server and run queries.
 
 > For Ubuntu 18.04 or 18.10, replace `16.04` in the following commands with `18.04` (the 18.04 repository is for both Ubuntu 18.04 and 18.10).
+
 ```terminal
 sudo su 
 curl https://packages.microsoft.com/keys/microsoft.asc | apt-key add -

--- a/_includes/partials/install_sqlcmd_linux_ubuntu.md
+++ b/_includes/partials/install_sqlcmd_linux_ubuntu.md
@@ -1,15 +1,25 @@
 [SQLCMD](https://docs.microsoft.com/en-us/sql/linux/sql-server-linux-connect-and-query-sqlcmd){:target="_blank"} is a command line tool that enables you to connect to SQL Server and run queries.
 
 ```terminal
-curl https://packages.microsoft.com/keys/microsoft.asc | sudo apt-key add -
-curl https://packages.microsoft.com/config/ubuntu/16.04/prod.list | sudo tee /etc/apt/sources.list.d/mssql-tools.list
+sudo su 
+curl https://packages.microsoft.com/keys/microsoft.asc | apt-key add -
+
+#Download appropriate package for the OS version
+#Choose only ONE of the following, corresponding to your OS version
+
+#Ubuntu 16.04
+curl https://packages.microsoft.com/config/ubuntu/16.04/prod.list > /etc/apt/sources.list.d/mssql-release.list
+
+#Ubuntu 18.04 and 18.10
+curl https://packages.microsoft.com/config/ubuntu/18.04/prod.list > /etc/apt/sources.list.d/mssql-release.list
+
+exit
 sudo apt-get update
-sudo ACCEPT_EULA=Y apt-get install mssql-tools
-sudo apt-get install unixodbc-dev
+sudo ACCEPT_EULA=Y apt-get install msodbcsql17 mssql-tools
 echo 'export PATH="$PATH:/opt/mssql-tools/bin"' >> ~/.bash_profile
 echo 'export PATH="$PATH:/opt/mssql-tools/bin"' >> ~/.bashrc
 source ~/.bashrc
-```
+sudo apt-get install unixodbc-dev```
 
 After installing SQLCMD, you can connect to SQL Server using the following command:
 

--- a/_includes/partials/install_sqlcmd_linux_ubuntu.md
+++ b/_includes/partials/install_sqlcmd_linux_ubuntu.md
@@ -1,18 +1,10 @@
 [SQLCMD](https://docs.microsoft.com/en-us/sql/linux/sql-server-linux-connect-and-query-sqlcmd){:target="_blank"} is a command line tool that enables you to connect to SQL Server and run queries.
 
+> For Ubuntu 18.04 or 18.10, replace `16.04` in the following commands with `18.04` (the 18.04 repository is for both Ubuntu 18.04 and 18.10).
 ```terminal
 sudo su 
 curl https://packages.microsoft.com/keys/microsoft.asc | apt-key add -
-
-#Download appropriate package for the OS version
-#Choose only ONE of the following, corresponding to your OS version
-
-#Ubuntu 16.04
 curl https://packages.microsoft.com/config/ubuntu/16.04/prod.list > /etc/apt/sources.list.d/mssql-release.list
-
-#Ubuntu 18.04 and 18.10
-curl https://packages.microsoft.com/config/ubuntu/18.04/prod.list > /etc/apt/sources.list.d/mssql-release.list
-
 exit
 sudo apt-get update
 sudo ACCEPT_EULA=Y apt-get install msodbcsql17 mssql-tools

--- a/_includes/partials/install_sqlcmd_mac.md
+++ b/_includes/partials/install_sqlcmd_mac.md
@@ -3,7 +3,7 @@
 ```terminal
 brew tap microsoft/mssql-release https://github.com/Microsoft/homebrew-mssql-release
 brew update
-HOMEBREW_NO_ENV_FILTERING=1 ACCEPT_EULA=y brew install --no-sandbox msodbcsql17 mssql-tools
+brew install --no-sandbox msodbcsql17 mssql-tools
 ```
 
 After installing SQLCMD, you can connect to SQL Server using the following command:

--- a/_includes/partials/install_sqlcmd_windows.md
+++ b/_includes/partials/install_sqlcmd_windows.md
@@ -3,14 +3,14 @@ SQLCMD is a command line tool that enables you to connect to SQL Server and run 
 1. Install the [**ODBC Driver**](https://www.microsoft.com/en-us/download/details.aspx?id=56567)
 2. Install the [**SQL Server Command Line Utilities**](https://www.microsoft.com/en-us/download/details.aspx?id=53591)
 
-After installing SQLCMD using the msi's, you can connect to SQL Server using the following command from a CMD session:
+After installing SQLCMD, you can connect to SQL Server using the following command from a CMD session:
 
 ```terminal
 sqlcmd -S localhost -U sa -P your_password
 1> # You're connected! Type your T-SQL statements here. Use the keyword 'GO' to execute each batch of statements.
 ```
 
-This how to run a basic inline query. The results will be printed to the STDOUT.
+This how to run a basic inline query. The results will be printed to STDOUT.
 ```terminal
 sqlcmd -S localhost -U sa -P yourpassword -Q "SELECT @@VERSION"
 ```

--- a/_includes/partials/php/columnstoreunix.md
+++ b/_includes/partials/php/columnstoreunix.md
@@ -1,6 +1,6 @@
 {% include partials/step3/title.md %}
 
-## Step 3.1 Create a new table with 5 million using sqlcmd
+## Step 3.1 Create a new table with 5 million rows using sqlcmd
 
 ```terminal
 sqlcmd -S localhost -U sa -P your_password -d SampleDB -t 60000 -Q "WITH a AS (SELECT * FROM (VALUES(1),(2),(3),(4),(5),(6),(7),(8),(9),(10)) AS a(a))
@@ -99,4 +99,4 @@ Sum: 50000000
 QueryTime: 5ms
 ```
 
-> Congrats you just made your PHP app faster using Columnstore Indexes! 
+> Congratulations! You just made your PHP app faster using Columnstore Indexes! 

--- a/_includes/partials/php/crudmac.md
+++ b/_includes/partials/php/crudmac.md
@@ -3,7 +3,7 @@
 
 ## Step 2.1 Install the PHP Drivers for SQL Server
 
-> If using PHP 7.3, replace sqlsrv and pdo_sqlsrv with sqlsrv-5.4.0preview and pdo_sqlsrv-5.4.0preview or later, as earlier versions are not compatible with PHP 7.3.
+> If using PHP 7.3, replace `sqlsrv` and `pdo_sqlsrv` in the following commands with `sqlsrv-5.4.0preview` and `pdo_sqlsrv-5.4.0preview` or later, as earlier versions are not compatible with PHP 7.3.
 
 ```terminal
     sudo pecl install pdo_sqlsrv

--- a/_includes/partials/php/crudmac.md
+++ b/_includes/partials/php/crudmac.md
@@ -1,17 +1,13 @@
 
 > In this section you will create a simple PHP app. The PHP app will perform basic Insert, Update, Delete, and Select.
 
-## Step 2.1 Install the PHP Driver for SQL Server
+## Step 2.1 Install the PHP Drivers for SQL Server
 
 > If using PHP 7.3, replace sqlsrv and pdo_sqlsrv with sqlsrv-5.4.0preview and pdo_sqlsrv-5.4.0preview or later, as earlier versions are not compatible with PHP 7.3.
 
 ```terminal
-sudo pecl install sqlsrv
-sudo pecl install pdo_sqlsrv
-sudo su
-echo extension=pdo_sqlsrv.so >> `php --ini | grep "Scan for additional .ini files" | sed -e "s|.*:\s*||"`/30-pdo_sqlsrv.ini
-echo extension=sqlsrv.so >> `php --ini | grep "Scan for additional .ini files" | sed -e "s|.*:\s*||"`/20-sqlsrv.ini
-exit
+    sudo pecl install pdo_sqlsrv
+    sudo pecl install sqlsrv
 ```
     
 ## Step 2.2 Create a database for your application 
@@ -164,3 +160,4 @@ Reading data from table
 
 
 > Congratulations! You have created your first PHP app with SQL Server! Check out the next section to learn about how you can make your PHP faster with SQL Server's Columnstore feature.
+

--- a/_includes/partials/php/crudunix-rhel.md
+++ b/_includes/partials/php/crudunix-rhel.md
@@ -13,7 +13,17 @@ echo extension=pdo_sqlsrv.so >> `php --ini | grep "Scan for additional .ini file
 echo extension=sqlsrv.so >> `php --ini | grep "Scan for additional .ini files" | sed -e "s|.*:\s*||"`/20-sqlsrv.ini
 exit
 ```
-    
+An issue in PECL may prevent correct installation of the latest version of the drivers even if you have upgraded GCC. To install, download the packages and compile manually (similar steps for pdo_sqlsrv):
+
+```terminal
+pecl download sqlsrv
+tar xvzf sqlsrv-5.3.0.tgz
+cd sqlsrv-5.3.0/
+phpize
+./configure --with-php-config=/usr/bin/php-config
+make
+sudo make install
+```
 ## Step 2.2 Create a database for your application 
 
 Create the database using sqlcmd

--- a/_includes/partials/php/crudunix-rhel.md
+++ b/_includes/partials/php/crudunix-rhel.md
@@ -3,7 +3,7 @@
 
 ## Step 2.1 Install the PHP Driver for SQL Server
 
-> If using PHP 7.3, replace sqlsrv and pdo_sqlsrv with sqlsrv-5.4.0preview and pdo_sqlsrv-5.4.0preview or later, as earlier versions are not compatible with PHP 7.3.
+> If using PHP 7.3, replace `sqlsrv` and `pdo_sqlsrv` in the following commands with `sqlsrv-5.4.0preview` and `pdo_sqlsrv-5.4.0preview` or later, as earlier versions are not compatible with PHP 7.3.
 
 ```terminal
 sudo pecl install sqlsrv

--- a/_includes/partials/php/crudunix.md
+++ b/_includes/partials/php/crudunix.md
@@ -3,7 +3,7 @@
 
 ## Step 2.1 Install the PHP Driver for SQL Server
 
-> If using PHP 7.3, replace sqlsrv and pdo_sqlsrv with sqlsrv-5.4.0preview and pdo_sqlsrv-5.4.0preview or later, as earlier versions are not compatible with PHP 7.3.
+> If using PHP 7.3, replace `sqlsrv` and `pdo_sqlsrv` in the following commands with `sqlsrv-5.4.0preview` and `pdo_sqlsrv-5.4.0preview` or later, as earlier versions are not compatible with PHP 7.3.
 
 ```terminal
 sudo pecl install sqlsrv

--- a/pages/php/mac/php-mac-1.md
+++ b/pages/php/mac/php-mac-1.md
@@ -23,21 +23,25 @@ redirect_from:
 
 3. Install PHP
 
+> To install PHP 7.0, 7.1, or 7.3, replace php@7.2 with php@7.0, php@7.1, or php@7.3 respectively in the following commands.
+
     ```terminal
     brew tap 
-    brew tap homebrew/dupes
-    brew tap homebrew/versions
-    brew tap homebrew/homebrew-php
-    brew install php70 --with-pear --with-httpd24 --with-cgi
-    echo 'export PATH="/usr/local/sbin:$PATH"' >> ~/.bash_profile
-    echo 'export PATH="/usr/local/bin:$PATH"' >> ~/.bash_profile
-    ```
+    brew tap homebrew/core
+    brew install php@7.2
+   ```
 
+PHP should now be in your path -- run `php -v` to verify that you are running the correct version of PHP. If PHP is not in your path or it is not the correct version, run the following:
+
+    ```terminal
+    brew link --force --overwrite php@7.2
+    ```
+    
 4. Install other required packages
 
 ```terminal
     brew install llvm --with-clang --with-clang-extra-tools
-    brew install autoconf
+    brew install autoconf automake libtool
 ```
 > You have successfully installed PHP on your macOS!
 

--- a/pages/php/mac/php-mac-1.md
+++ b/pages/php/mac/php-mac-1.md
@@ -23,7 +23,7 @@ redirect_from:
 
 3. Install PHP
 
-> To install PHP 7.0, 7.1, or 7.3, replace php@7.2 with php@7.0, php@7.1, or php@7.3 respectively in the following commands.
+> To install PHP 7.0, 7.1, or 7.3, replace `php@7.2` with `php@7.0`, `php@7.1`, or `php@7.3` respectively in the following commands.
 
     ```terminal
     brew tap 
@@ -40,7 +40,6 @@ PHP should now be in your path -- run `php -v` to verify that you are running th
 4. Install other required packages
 
 ```terminal
-    brew install llvm --with-clang --with-clang-extra-tools
     brew install autoconf automake libtool
 ```
 > You have successfully installed PHP on your macOS!

--- a/pages/php/mac/php-mac-2.md
+++ b/pages/php/mac/php-mac-2.md
@@ -5,5 +5,5 @@ title: macOS
 permalink: /php/mac/step/2
 ---
 
-{% include partials/php/crudunix.md %}
+{% include partials/php/crudmac.md %}
 

--- a/pages/php/rhel/php-rhel-1.md
+++ b/pages/php/rhel/php-rhel-1.md
@@ -16,6 +16,7 @@ redirect_from:
 
 ## Step 1.2 Install PHP and other required packages
 
+> To install PHP 7.0, 7.1, or 7.3, replace remi-php72 with remi-php70, remi-php71, or remi-php73 respectively in the following commands.
 
 ```terminal
     wget https://dl.fedoraproject.org/pub/epel/epel-release-latest-7.noarch.rpm
@@ -23,11 +24,19 @@ redirect_from:
     rpm -Uvh remi-release-7.rpm epel-release-latest-7.noarch.rpm
     subscription-manager repos --enable=rhel-7-server-optional-rpms
     yum install yum-utils
-    yum-config-manager --enable remi-php70
+    yum-config-manager --enable remi-php72
     yum update
-    yum install php httpd php-cli php-common php-pdo php-devel php-fpm php-mbstring php-mcrypt php-pear
+    yum install php php-pdo php-xml php-pear php-devel re2c gcc-c++ gcc
 ```
 
+> Compiling the PHP drivers with PECL with PHP 7.2 requires a more recent GCC than the default:
+
+```terminal
+   sudo yum-config-manager --enable rhel-server-rhscl-7-rpms
+   sudo yum install devtoolset-7
+   scl enable devtoolset-7 bash
+```
+    
 > You have successfuly installed PHP on your RHEL machine! 
 
 > SELinux is installed by default and runs in Enforcing mode. To allow Apache to connect to a database through SELinux, run the following command: 

--- a/pages/php/rhel/php-rhel-1.md
+++ b/pages/php/rhel/php-rhel-1.md
@@ -19,6 +19,7 @@ redirect_from:
 > To install PHP 7.0, 7.1, or 7.3, replace `remi-php72` with `remi-php70`, `remi-php71`, or `remi-php73` respectively in the following commands.
 
 ```terminal
+    sudo su
     wget https://dl.fedoraproject.org/pub/epel/epel-release-latest-7.noarch.rpm
     wget http://rpms.remirepo.net/enterprise/remi-release-7.rpm
     rpm -Uvh remi-release-7.rpm epel-release-latest-7.noarch.rpm

--- a/pages/php/rhel/php-rhel-1.md
+++ b/pages/php/rhel/php-rhel-1.md
@@ -16,7 +16,7 @@ redirect_from:
 
 ## Step 1.2 Install PHP and other required packages
 
-> To install PHP 7.0, 7.1, or 7.3, replace remi-php72 with remi-php70, remi-php71, or remi-php73 respectively in the following commands.
+> To install PHP 7.0, 7.1, or 7.3, replace `remi-php72` with `remi-php70`, `remi-php71`, or `remi-php73` respectively in the following commands.
 
 ```terminal
     wget https://dl.fedoraproject.org/pub/epel/epel-release-latest-7.noarch.rpm

--- a/pages/php/rhel/php-rhel-2.md
+++ b/pages/php/rhel/php-rhel-2.md
@@ -5,5 +5,5 @@ title: RHEL
 permalink: /php/rhel/step/2
 ---
 
-{% include partials/php/crudunix.md %}
+{% include partials/php/crudunix-rhel.md %}
 

--- a/pages/php/sles/php-suse-1.md
+++ b/pages/php/sles/php-suse-1.md
@@ -16,10 +16,11 @@ redirect_from:
 
 ## Step 1.2 Install PHP and other required packages
 
-> To install PHP 7.0, skip the command below adding the repository - 7.0 is the default PHP on suse 12. To install PHP 7.1, replace the repository URL below with the following URL: `https://download.opensuse.org/repositories/devel:/languages:/php:/php71/SLE_12_SP1/devel:languages:php:php71.repo`
+> To install PHP 7.0 or 7.1, replace the repository URL below with one of the following URLs: `https://download.opensuse.org/repositories/devel:languages:php:php70/SLE_12_SP3/devel:languages:php:php70.repo`
+`https://download.opensuse.org/repositories/devel:languages:php:php71/SLE_12_SP3/devel:languages:php:php71.repo`
 
 ```terminal
-    sudo zypper -n ar -f https://download.opensuse.org/repositories/devel:languages:php/SLE_12_SP1/devel:languages:php.repo
+    sudo zypper -n ar -f https://download.opensuse.org/repositories/devel:languages:php/SLE_12_SP3/devel:languages:php.repo
     sudo zypper --gpg-auto-import-keys refresh
     sudo zypper install php7 php7-pear php7-devel
 ```

--- a/pages/php/sles/php-suse-1.md
+++ b/pages/php/sles/php-suse-1.md
@@ -20,9 +20,10 @@ redirect_from:
 `https://download.opensuse.org/repositories/devel:languages:php:php71/SLE_12_SP3/devel:languages:php:php71.repo`
 
 ```terminal
-    sudo zypper -n ar -f https://download.opensuse.org/repositories/devel:languages:php/SLE_12_SP3/devel:languages:php.repo
-    sudo zypper --gpg-auto-import-keys refresh
-    sudo zypper install php7 php7-pear php7-devel
+    sudo su
+    zypper -n ar -f https://download.opensuse.org/repositories/devel:languages:php/SLE_12_SP3/devel:languages:php.repo
+    zypper --gpg-auto-import-keys refresh
+    zypper install php7 php7-pear php7-devel
 ```
 > You have successfully installed PHP on your SLES machine! 
 

--- a/pages/php/sles/php-suse-1.md
+++ b/pages/php/sles/php-suse-1.md
@@ -16,10 +16,12 @@ redirect_from:
 
 ## Step 1.2 Install PHP and other required packages
 
+> To install PHP 7.0, skip the command below adding the repository - 7.0 is the default PHP on suse 12. To install PHP 7.1, replace the repository URL below with the following URL: `https://download.opensuse.org/repositories/devel:/languages:/php:/php71/SLE_12_SP1/devel:languages:php:php71.repo`
 
 ```terminal
-    sudo zypper update
-    sudo zypper install php7 php7-devel php7-openssl php7-phar php7-mcrypt php7-mbstring php7-pear gcc gcc-c++ make apache2
+    sudo zypper -n ar -f https://download.opensuse.org/repositories/devel:languages:php/SLE_12_SP1/devel:languages:php.repo
+    sudo zypper --gpg-auto-import-keys refresh
+    sudo zypper install php7 php7-pear php7-devel
 ```
 > You have successfully installed PHP on your SLES machine! 
 

--- a/pages/php/ubuntu/php-ubuntu-1.md
+++ b/pages/php/ubuntu/php-ubuntu-1.md
@@ -19,6 +19,7 @@ redirect_from:
 > To install PHP 7.0, 7.1, or 7.3, replace `7.2` with `7.0`, `7.1`, or `7.3` in the following commands.
 
 ```terminal
+sudo su
 add-apt-repository ppa:ondrej/php -y
 apt-get update
 apt-get install php7.2 php7.2-dev php7.2-xml -y --allow-unauthenticated

--- a/pages/php/ubuntu/php-ubuntu-1.md
+++ b/pages/php/ubuntu/php-ubuntu-1.md
@@ -16,8 +16,12 @@ redirect_from:
 
 ## Step 1.2 Install PHP and other required packages
 
+> To install PHP 7.0, 7.1, or 7.3, replace 7.2 with 7.0, 7.1, or 7.3 in the following commands.
+
 ```terminal
-  sudo apt-get -y install php7.0 libapache2-mod-php7.0 mcrypt php7.0-mcrypt php-mbstring php-pear php7.0-dev apache2
+add-apt-repository ppa:ondrej/php -y
+apt-get update
+apt-get install php7.2 php7.2-dev php7.2-xml -y --allow-unauthenticated
 ```
 > You have successfully installed PHP on your Ubuntu machine! 
 ## Step 1.3 Install the ODBC Driver and SQL Command Line Utility for SQL Server

--- a/pages/php/ubuntu/php-ubuntu-1.md
+++ b/pages/php/ubuntu/php-ubuntu-1.md
@@ -16,7 +16,7 @@ redirect_from:
 
 ## Step 1.2 Install PHP and other required packages
 
-> To install PHP 7.0, 7.1, or 7.3, replace 7.2 with 7.0, 7.1, or 7.3 in the following commands.
+> To install PHP 7.0, 7.1, or 7.3, replace `7.2` with `7.0`, `7.1`, or `7.3` in the following commands.
 
 ```terminal
 add-apt-repository ppa:ondrej/php -y

--- a/pages/php/windows/php-windows-2.md
+++ b/pages/php/windows/php-windows-2.md
@@ -11,16 +11,16 @@ permalink: /php/windows/step/2
 
 Download the Microsoft PHP Drivers for SQL Server from the [download center](https://www.microsoft.com/en-us/download/details.aspx?id=57163)
 
-Pick the appropriate dll - for example **php_pdo_sqlsrv_71_nts** for the **PDO Driver** and **php_sqlsrv_71_nts** for the **SQLSRV driver**
+Pick the appropriate dll - for example **php_pdo_sqlsrv_72_nts** for the **PDO Driver** and **php_sqlsrv_72_nts** for the **SQLSRV driver**
 
-Copy the dll's to the **C:\Program Files\iis express\PHP\v7.1\ext** folder
+Copy the dll's to the **C:\Program Files\iis express\PHP\v7.2\ext** folder
 
 Register the dll's in the **php.ini** file
 
 ```terminal
-    cd C:\Program^ Files\iis^ express\PHP\v7.1\ext
-    echo extension=php_sqlsrv_71_nts.dll >> C:\Program^ Files\iis^ express\PHP\v7.1\php.ini
-    echo extension=php_pdo_sqlsrv_71_nts.dll >> C:\Program^ Files\iis^ express\PHP\v7.1\php.ini
+    cd C:\Program^ Files\iis^ express\PHP\v7.2\ext
+    echo extension=php_sqlsrv_72_nts.dll >> C:\Program^ Files\iis^ express\PHP\v7.2\php.ini
+    echo extension=php_pdo_sqlsrv_72_nts.dll >> C:\Program^ Files\iis^ express\PHP\v7.2\php.ini
 ```
     
 ## Step 2.2 Create a database for your application 
@@ -172,4 +172,4 @@ Reading data from table
 ```
 
 
-> Congrats you created your first PHP app with SQL Server! Check out the next section to learn about how you can make your PHP faster with SQL Server's Columnstore feature.
+> Congratulations! You have created your first PHP app with SQL Server! Check out the next section to learn about how you can make your PHP faster with SQL Server's Columnstore feature.

--- a/pages/php/windows/php-windows-3.md
+++ b/pages/php/windows/php-windows-3.md
@@ -106,4 +106,4 @@ Sum: 50000000
 QueryTime: 5ms
 ```
 
-> Congrats you just made your PHP app faster using Columnstore Indexes! 
+> Congratulations! You just made your PHP app faster using Columnstore Indexes! 


### PR DESCRIPTION
I added php 7.3 instructions to mac documents even though it's not yet available in anticipation that it will be added to brew very shortly after 7.3 goes GA. I have not added 7.3 instructions for Suse because I don't know if they will add it to their repos soon or what the repo URL would be. For other platforms 7.3 is already available.