### PR TITLE
Fix go sample instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 
 # SQL Server Tutorials Documentation Contributor Guide
-You've found the GitHub repository that houses the source for the SQL Server tutorials that are published on [http://aka.ms/sqldev](http://aka.ms/sqldev).
+You've found the GitHub repository that houses the source for the SQL Server tutorials that are published on [https://aka.ms/sqldev](https://aka.ms/sqldev).
 
 
 ## Contribute to SQL Server tutorials 

--- a/_includes/partials/az-install_sqlcmd_windows.md
+++ b/_includes/partials/az-install_sqlcmd_windows.md
@@ -1,6 +1,6 @@
 SQLCMD is a command line tool that enables you to connect to Azure SQL or SQL Server and run queries.
 
-1. Install the [**ODBC Driver**](https://docs.microsoft.com/sql/connect/odbc/download-odbc-driver-for-sql-server).
+1. Install the [**ODBC Driver**](https://aka.ms/downloadmsodbcsql).
 2. Install the [**SQL Server Command Line Utilities**](https://docs.microsoft.com/sql/tools/sqlcmd-utility).
 
 After installing SQLCMD, you can connect to Azure SQL using the following command from a CMD session, making sure to update your connection information:

--- a/_includes/partials/go/az-crudunix.md
+++ b/_includes/partials/go/az-crudunix.md
@@ -1,5 +1,5 @@
 
-> After getting Azure SQL DB set up and GoLang installed, you can now proceed to create your new Go projects. Here we will explore three simple applications. One of them will connect and print the Azure SQL version of your database server, the other one will perform basic Insert, Update, Delete, and Select operations, and the third one will make use of [GORM](http://jinzhu.me/gorm/), a popular object relational mapping (ORM) framework for Go to execute the same operations.
+> After getting Azure SQL DB set up and GoLang installed, you can now proceed to create your new Go projects. Here we will explore three simple applications. One of them will connect and print the Azure SQL version of your database server, the other one will perform basic Insert, Update, Delete, and Select operations, and the third one will make use of [GORM](https://github.com/jinzhu/gorm/), a popular object relational mapping (ORM) framework for Go to execute the same operations.
 
 ## Get Connection Information to use in Connection Strings, and Create a Firewall Rule.
 
@@ -16,9 +16,8 @@ Create a new project directory and install Go dependencies.
     mkdir AzureSqlSample
     cd AzureSqlSample
 
-    # Get and install the Azure SQL DB driver for Go
+    # Get the Azure SQL DB driver for Go
     go get github.com/denisenkom/go-mssqldb
-    go install github.com/denisenkom/go-mssqldb
 ```
 
 Now you will create a simple Go app that connects to Azure SQL DB.
@@ -365,13 +364,11 @@ Create the app directory and initialize Go dependencies.
     mkdir AzureSqlGormSample
     cd AzureSqlGormSample
 
-    # Get and install the SQL Server driver for Go
+    # Get the SQL Server driver for Go
     go get github.com/denisenkom/go-mssqldb
-    go install github.com/denisenkom/go-mssqldb
 
-   # Get and install GORM
+   # Get GORM
    go get github.com/jinzhu/gorm
-   go install github.com/jinzhu/gorm
 ```
 
 Paste the contents below into a file called `orm.go`. Make sure to replace the password variable to your own.

--- a/_includes/partials/go/crudunix.md
+++ b/_includes/partials/go/crudunix.md
@@ -1,5 +1,5 @@
 
-> After getting SQL Server and GoLang installed, you can now proceed to create your new Go projects. Here we will explore three simple applications. One of them will connect and print the SQL Server version of your database server, the other one will perform basic Insert, Update, Delete, and Select operations, and the third one will make use of [GORM](http://jinzhu.me/gorm/), a popular object relational mapping (ORM) framework for Go to execute the same operations.
+> After getting SQL Server and GoLang installed, you can now proceed to create your new Go projects. Here we will explore three simple applications. One of them will connect and print the SQL Server version of your database server, the other one will perform basic Insert, Update, Delete, and Select operations, and the third one will make use of [GORM](https://github.com/jinzhu/gorm/), a popular object relational mapping (ORM) framework for Go to execute the same operations.
 
 ## Create a Go app that connects to SQL Server and executes queries
 
@@ -12,9 +12,8 @@ Create a new project directory and install Go dependencies.
     mkdir SqlServerSample
     cd SqlServerSample
 
-    # Get and install the SQL Server driver for Go
+    # Get the SQL Server driver for Go
     go get github.com/denisenkom/go-mssqldb
-    go install github.com/denisenkom/go-mssqldb
 ```
 
 Create a database that will be used for the rest of this tutorial by connecting to SQL Server using sqlcmd and executing the following command. Don't forget to update the username and password with your own.
@@ -384,10 +383,11 @@ Create the app directory and initialize Go dependencies.
     mkdir SqlServerGormSample
     cd SqlServerGormSample
 
-    # Get and install the SQL Server driver for Go
+    # Get the SQL Server driver for Go
     go get github.com/denisenkom/go-mssqldb
-    go install github.com/denisenkom/go-mssqldb
-```
+
+   # Get GORM
+   go get github.com/jinzhu/gorm```
 
 Paste the contents below into a file called `orm.go`. Make sure to replace the password variable to your own.
 

--- a/_includes/partials/install_sqlcmd_windows.md
+++ b/_includes/partials/install_sqlcmd_windows.md
@@ -1,6 +1,6 @@
 SQLCMD is a command line tool that enables you to connect to SQL Server and run queries.
 
-1. Install the [**ODBC Driver**](https://docs.microsoft.com/sql/connect/odbc/download-odbc-driver-for-sql-server).
+1. Install the [**ODBC Driver**](https://aka.ms/downloadmsodbcsql).
 2. Install the [**SQL Server Command Line Utilities**](https://docs.microsoft.com/sql/tools/sqlcmd-utility).
 
 After installing SQLCMD, you can connect to SQL Server using the following command from a CMD session:

--- a/pages/go/windows/az/az-go-windows-2.md
+++ b/pages/go/windows/az/az-go-windows-2.md
@@ -5,9 +5,9 @@ title: Windows
 permalink: /go/windows/az/step/2
 ---
 
-> After getting Azure SQL set up and GoLang installed, you can now proceed to create your new Go projects. Here we will explore three simple applications. One of them will connect and print the Azure SQL version of your database server, the other one will perform basic Insert, Update, Delete, and Select operations, and the third one will make use of [GORM](http://jinzhu.me/gorm/), a popular object relational mapping (ORM) framework for Go to execute the same operations.
+> After getting Azure SQL set up and GoLang installed, you can now proceed to create your new Go projects. Here we will explore three simple applications. One of them will connect and print the Azure SQL version of your database server, the other one will perform basic Insert, Update, Delete, and Select operations, and the third one will make use of [GORM](https://github.com/jinzhu/gorm), a popular object relational mapping (ORM) framework for Go to execute the same operations.
 
-## Get Connection Information to use in Connection Strings, and Create a Firewall Rule.
+## Get Connection Information to use in Connection Strings, and Create a Firewall Rule
 
 {% include partials/get_azure_sql_connection_info.md %}
 
@@ -22,9 +22,8 @@ Create a new project directory and install Go dependencies.
     mkdir AzureSqlSample
     cd AzureSqlSample
 
-    # Get and install the Azure SQL driver for Go
+    # Get the Azure SQL driver for Go
     go get github.com/denisenkom/go-mssqldb
-    go install github.com/denisenkom/go-mssqldb
 ```
 
 Now you will create a simple Go app that connects to Azure SQL.
@@ -343,13 +342,11 @@ Create the app directory and initialize Go dependencies.
     mkdir AzureSqlGormSample
     cd AzureSqlGormSample
 
-    # Get and install the Azure SQL driver for Go
+    # Get the Azure SQL driver for Go
     go get github.com/denisenkom/go-mssqldb
-    go install github.com/denisenkom/go-mssqldb
 
-   # Get and install GORM
+   # Get GORM
    go get github.com/jinzhu/gorm
-   go install github.com/jinzhu/gorm
 ```
 
 Paste the contents below into a file called `orm.go`. Make sure to replace the password variable to your own.

--- a/pages/go/windows/go-windows-2.md
+++ b/pages/go/windows/go-windows-2.md
@@ -5,7 +5,7 @@ title: Windows
 permalink: /go/windows/server/step/2
 ---
 
-> After getting SQL Server and GoLang installed, you can now proceed to create your new Go projects. Here we will explore three simple applications. One of them will connect and print the SQL Server version of your database server, the other one will perform basic Insert, Update, Delete, and Select operations, and the third one will make use of [GORM](http://jinzhu.me/gorm/), a popular object relational mapping (ORM) framework for Go to execute the same operations.
+> After getting SQL Server and GoLang installed, you can now proceed to create your new Go projects. Here we will explore three simple applications. One of them will connect and print the SQL Server version of your database server, the other one will perform basic Insert, Update, Delete, and Select operations, and the third one will make use of [GORM](https://github.com/jinzhu/gorm), a popular object relational mapping (ORM) framework for Go to execute the same operations.
 
 ## Create a Go app that connects to SQL Server and executes queries
 
@@ -18,9 +18,8 @@ Create a new project directory and install Go dependencies.
     md SqlServerSample
     cd SqlServerSample
 
-    # Get and install the SQL Server driver for Go
+    # Get the SQL Server driver for Go
     go get github.com/denisenkom/go-mssqldb
-    go install github.com/denisenkom/go-mssqldb
 ```
 
 Create a database that will be used for the rest of this tutorial by connecting to SQL Server using sqlcmd and executing the following command. Don't forget to update the username and password with your own.
@@ -365,9 +364,11 @@ Create the app directory and initialize Go dependencies.
     md SqlServerGormSample
     cd SqlServerGormSample
 
-    # Get and install the SQL Server driver for Go
+    # Get the SQL Server driver for Go
     go get github.com/denisenkom/go-mssqldb
-    go install github.com/denisenkom/go-mssqldb
+
+   # Get GORM
+   go get github.com/jinzhu/gorm
 ```
 
 Paste the contents below into a file called `orm.go`. Make sure to replace the password variable to your own.

--- a/pages/php/windows/az/az-php-windows-2.md
+++ b/pages/php/windows/az/az-php-windows-2.md
@@ -7,15 +7,15 @@ permalink: /php/windows/az/step/2
 
 > In this section you will create a simple PHP app. The PHP app will perform basic Insert, Update, Delete, and Select.
 
-## Step 2.1 Get Connection Information to use in Connection Strings, and Create a Firewall Rule.
+## Step 2.1 Get Connection Information to use in Connection Strings, and Create a Firewall Rule
 
 {% include partials/get_azure_sql_connection_info.md %}
 
 ## Step 2.2 Install the PHP Drivers for Azure SQL DB
 
-If you have used the [**Web Platform Installer**](https://www.microsoft.com/web/downloads/platform.aspx) in Step 1 to install the Microsoft PHP Drivers for SQL Server, you can skip this step. Otherwise, download the drivers from the [download page](https://docs.microsoft.com/sql/connect/php/download-drivers-php-sql-server).
+If you have used the [**Web Platform Installer**](https://www.microsoft.com/web/downloads/platform.aspx) in Step 1 to install the Microsoft PHP Drivers for SQL Server, you can skip this step. Otherwise, download the drivers from the [download page](https://aka.ms/downloadmsphpsql).
 
-For example, if you have downloaded **'PHP 8.0.0 (x64)'** using the Web Platform Installer, select **php_pdo_sqlsrv_80_nts.dll** for the **PDO_SQLSRV Driver** and/or **php_sqlsrv_80_nts.dll** for the **SQLSRV driver**. Copy the dll file(s) to the **C:\Program Files\PHP\v8.0\ext** folder. 
+For example, if you have downloaded **'PHP 8.0.0 (x64)'** using the Web Platform Installer, select **php_pdo_sqlsrv_80_nts.dll** for the **PDO_SQLSRV Driver** and/or **php_sqlsrv_80_nts.dll** for the **SQLSRV driver**. Copy the dll file(s) to the **C:\Program Files\PHP\v8.0\ext** folder.
 
 Enable Microsoft PHP Drivers for SQL Server by modifying the **php.ini** file. First, navigate to **C:\Program Files\PHP\v8.0**. If you do not find the **php.ini** file, make a copy of either **php.ini-development** or **php.ini-production** (depending on whether your system is a development environment or production environment) and rename it **php.ini**.
 

--- a/pages/php/windows/php-windows-2.md
+++ b/pages/php/windows/php-windows-2.md
@@ -9,9 +9,9 @@ permalink: /php/windows/server/step/2
 
 ## Step 2.1 Install the PHP Drivers for SQL Server
 
-If you have used the [**Web Platform Installer**](https://www.microsoft.com/web/downloads/platform.aspx) in Step 1 to install the Microsoft PHP Drivers for SQL Server, you can skip this step. Otherwise, download the drivers from the [download page](https://docs.microsoft.com/sql/connect/php/download-drivers-php-sql-server).
+If you have used the [**Web Platform Installer**](https://www.microsoft.com/web/downloads/platform.aspx) in Step 1 to install the Microsoft PHP Drivers for SQL Server, you can skip this step. Otherwise, download the drivers from the [download page](https://aka.ms/downloadmsphpsql).
 
-For example, if you have downloaded **'PHP 8.0.0 (x64)'** using the Web Platform Installer, select **php_pdo_sqlsrv_80_nts.dll** for the **PDO_SQLSRV Driver** and/or **php_sqlsrv_80_nts.dll** for the **SQLSRV driver**. Copy the dll file(s) to the **C:\Program Files\PHP\v8.0\ext** folder. 
+For example, if you have downloaded **'PHP 8.0.0 (x64)'** using the Web Platform Installer, select **php_pdo_sqlsrv_80_nts.dll** for the **PDO_SQLSRV Driver** and/or **php_sqlsrv_80_nts.dll** for the **SQLSRV driver**. Copy the dll file(s) to the **C:\Program Files\PHP\v8.0\ext** folder.
 
 Enable Microsoft PHP Drivers for SQL Server by modifying the **php.ini** file. First, navigate to **C:\Program Files\PHP\v8.0**. If you do not find the **php.ini** file, make a copy of either **php.ini-development** or **php.ini-production** (depending on whether your system is a development environment or production environment) and rename it **php.ini**.
 


### PR DESCRIPTION
The `go install` command doesn't work in Go 1.16 and doesn't seem to be needed anymore.

Also fixed some link references.